### PR TITLE
Minor changes to make the usage and development easier

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+venv/
 /*_old/
 /.idea/
 /plots/

--- a/artifact_simulator.py
+++ b/artifact_simulator.py
@@ -190,7 +190,7 @@ def take_input(defaults=(1, 50)):
 
 def load_inventory():
     try:
-        with open('.\\inventory.txt') as file:
+        with open('inventory.txt') as file:
             data = file.read()
         inv = json.loads(data)
         inv = [Artifact(a[0], a[1], a[2], a[3], a[4], a[5], a[6], a[7]) for a in inv]
@@ -198,7 +198,7 @@ def load_inventory():
         return inv
 
     except FileNotFoundError:
-        with open('.\\inventory.txt', 'w') as file:
+        with open('inventory.txt', 'w') as file:
             file.write('[]')
         return []
 
@@ -340,7 +340,7 @@ def upgrade_to_max_tier(artifact, do_we_print=2, extra_space=False):  # 2 - prin
 
 
 def save_inventory_to_file(artifacts):
-    with open(r'.\inventory.txt', 'w') as f:
+    with open('inventory.txt', 'w') as f:
         f.write(json.dumps(artifacts, cls=ArtifactEncoder, separators=(',', ':')))
 
 

--- a/simulator.py
+++ b/simulator.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 import importlib
 import os
 import sys

--- a/simulator_for_plotting.py
+++ b/simulator_for_plotting.py
@@ -504,10 +504,11 @@ if __name__ == "__main__":
     print('List:', days_for_plotting)
     print()
 
-    Path(".\\plots").mkdir(parents=True, exist_ok=True)
-    Path(f".\\plots\\sample size = {sample_size}").mkdir(parents=True, exist_ok=True)
+    Path('plots', f'sample size = {sample_size}').mkdir(parents=True, exist_ok=True)
 
-    with open(f'.\\plots\\sample size = {sample_size}\\{cv_desired}CV - {sample_size} at {str(datetime.datetime.now())[:-7].replace(":", "-")}.txt', 'w') as file:
+    with open(Path('plots')
+              / f'sample size = {sample_size}'
+              / '{cv_desired}CV - {sample_size} at {str(datetime.datetime.now())[:-7].replace(":", "-")}.txt', 'w') as file:
         file.write(json.dumps(days_for_plotting))
 
     plot_this(cv_for_plotting, days_for_plotting, [0.0, cv_desired], sample_size, cv_desired)

--- a/visualize_character_distribution.py
+++ b/visualize_character_distribution.py
@@ -2,6 +2,8 @@ import json
 import numpy as np
 import matplotlib.pyplot as plt
 
+from pathlib import Path
+
 
 def jsonKeys2int(x):
     if isinstance(x, dict):
@@ -10,7 +12,7 @@ def jsonKeys2int(x):
 
 
 try:
-    with open('.\\banner_info\\character_distribution.txt') as file:
+    with open(Path('banner_info', 'character_distribution.txt')) as file:
         data = file.read()
     character_distribution = json.loads(data, object_hook=jsonKeys2int)
     num = character_distribution.pop(100)

--- a/visualize_weapon_distribution.py
+++ b/visualize_weapon_distribution.py
@@ -2,6 +2,8 @@ import json
 import numpy as np
 import matplotlib.pyplot as plt
 
+from pathlib import Path
+
 
 def jsonKeys2int(x):
     if isinstance(x, dict):
@@ -10,7 +12,7 @@ def jsonKeys2int(x):
 
 
 try:
-    with open('.\\banner_info\\weapon_distribution.txt') as file:
+    with open(Path('banner_info', 'weapon_distribution.txt')) as file:
         data = file.read()
     weapon_distribution = json.loads(data, object_hook=jsonKeys2int)
     num = weapon_distribution.pop(100)

--- a/wish_simulator.py
+++ b/wish_simulator.py
@@ -6,6 +6,8 @@ import sys
 import importlib
 import os
 
+from pathlib import Path
+
 
 try:
     os.environ['replit']
@@ -19,26 +21,26 @@ except KeyError:
 
 print(f'\n===================== {Fore.LIGHTCYAN_EX}LOADING WISH SIMULATOR{Style.RESET_ALL} =====================\n')
 init()
-Path(".\\banner_info").mkdir(parents=True, exist_ok=True)
+Path('banner_info').mkdir(parents=True, exist_ok=True)
 
 
 def save_character_history_to_file():
-    with open(r'.\banner_info\character_wish_history.txt', 'w') as f:
+    with open(Path('banner_info', 'character_wish_history.txt'), 'w') as f:
         f.write(json.dumps(wish_history["character"], separators=(',', ':')))
 
 
 def save_weapon_history_to_file():
-    with open(r'.\banner_info\weapon_wish_history.txt', 'w') as f:
+    with open(Path('banner_info', 'weapon_wish_history.txt'), 'w') as f:
         f.write(json.dumps(wish_history["weapon"], separators=(',', ':')))
 
 
 def save_standard_history_to_file():
-    with open(r'.\banner_info\standard_wish_history.txt', 'w') as f:
+    with open(Path('banner_info', 'standard_wish_history.txt'), 'w') as f:
         f.write(json.dumps(wish_history["standard"], separators=(',', ':')))
 
 
 def save_chronicled_history_to_file():
-    with open(r'.\banner_info\chronicled_wish_history.txt', 'w') as f:
+    with open(Path('banner_info', 'chronicled_wish_history.txt'), 'w') as f:
         f.write(json.dumps(wish_history["chronicled"], separators=(',', ':')))
 
 
@@ -50,16 +52,16 @@ saving_dict = {"character": save_character_history_to_file,
 
 def load_history():
     try:
-        with open(r'.\banner_info\character_wish_history.txt') as file:
+        with open(Path('banner_info', 'character_wish_history.txt')) as file:
             data = file.read()
         character_history = json.loads(data)
-        with open(r'.\banner_info\weapon_wish_history.txt') as file:
+        with open(Path('banner_info', 'weapon_wish_history.txt')) as file:
             data = file.read()
         weapon_history = json.loads(data)
-        with open(r'.\banner_info\standard_wish_history.txt') as file:
+        with open(Path('banner_info', 'standard_wish_history.txt')) as file:
             data = file.read()
         standard_history = json.loads(data)
-        with open(r'.\banner_info\chronicled_wish_history.txt') as file:
+        with open(Path('banner_info', 'chronicled_wish_history.txt')) as file:
             data = file.read()
         chronicled_history = json.loads(data)
         for i in character_history + weapon_history + standard_history + chronicled_history:
@@ -79,22 +81,22 @@ def load_history():
 
 
 def save_character_distribution_to_file():
-    with open(r'.\banner_info\character_distribution.txt', 'w') as f:
+    with open(Path('banner_info', 'character_distribution.txt'), 'w') as f:
         f.write(json.dumps(character_distribution, separators=(',', ':')))
 
 
 def save_weapon_distribution_to_file():
-    with open(r'.\banner_info\weapon_distribution.txt', 'w') as f:
+    with open(Path('banner_info', 'weapon_distribution.txt'), 'w') as f:
         f.write(json.dumps(weapon_distribution, separators=(',', ':')))
 
 
 def save_info_to_file(pity, count_, five_count_, four_count_, unique_five_char_count_, unique_five_weap_count_, unique_four_weap_count_):
-    with open(r'.\banner_info\info.txt', 'w') as f:
+    with open(Path('banner_info', 'info.txt'), 'w') as f:
         f.write(json.dumps([pity, count_, five_count_, four_count_, unique_five_char_count_, unique_five_weap_count_, unique_four_weap_count_], separators=(',', ':')))
 
 
 def save_banner_to_file():
-    with open(r'.\banner_info\banner.txt', 'w') as f:
+    with open(Path('banner_info', 'banner.txt'), 'w') as f:
         f.write(json.dumps(user_banner_input, separators=(',', ':')))
 
 
@@ -104,7 +106,7 @@ def save_archive_to_file(cons, refs):
     numeric_indexes_w = [weapon.num for weapon in refs]
     new_dict_c = dict(zip(numeric_indexes_c, list(cons.values())))
     new_dict_w = dict(zip(numeric_indexes_w, list(refs.values())))
-    with open(r'.\banner_info\archive.txt', 'w') as f:
+    with open(Path('banner_info', 'archive.txt'), 'w') as f:
         data = (new_dict_c, new_dict_w)
         f.write(json.dumps(data, separators=(',', ':')))
 
@@ -114,7 +116,7 @@ banner_types = ["character", "weapon", "standard", "chronicled"]
 
 def load_info():
     try:
-        with open('.\\banner_info\\info.txt') as file:
+        with open(Path('banner_info', 'info.txt')) as file:
             data = file.read()
         pity_and_other_info = json.loads(data)
         return pity_and_other_info
@@ -126,7 +128,7 @@ def load_info():
             'standard': [0, 0, 0, 0, [0, 0, 0]],
             'chronicled': [0, 0, False, [0, 0, 0]]
         }
-        with open('.\\banner_info\\info.txt', 'w') as file:
+        with open(Path('banner_info', 'info.txt'), 'w') as file:
             info = [pities_, 0, 0, 0, 0, 0, 0]
             file.write(json.dumps(info, separators=(',', ':')))
         return info
@@ -135,7 +137,7 @@ def load_info():
 def load_banner():  # always returns a valid banner
     global user_banner_input
     try:  # if can read, read.
-        with open('.\\banner_info\\banner.txt') as file:
+        with open(Path('banner_info', 'banner.txt')) as file:
             data = file.read()
         user_banner_input = json.loads(data)
         check_for_banner_mismatch_and_save()  # make sure what was read is a valid banner and save variables
@@ -153,7 +155,7 @@ def jsonKeys2int(x):
 def load_distribution():
     global character_distribution, weapon_distribution
     try:
-        with open('.\\banner_info\\character_distribution.txt') as file:
+        with open(Path('banner_info', 'character_distribution.txt')) as file:
             data = file.read()
         character_distribution = json.loads(data, object_hook=jsonKeys2int)
 
@@ -163,7 +165,7 @@ def load_distribution():
         save_character_distribution_to_file()
 
     try:
-        with open('.\\banner_info\\weapon_distribution.txt') as file:
+        with open(Path('banner_info', 'weapon_distribution.txt')) as file:
             data = file.read()
         weapon_distribution = json.loads(data, object_hook=jsonKeys2int)
 
@@ -177,7 +179,7 @@ def load_distribution():
 
 def load_archive():
     try:
-        with open('.\\banner_info\\archive.txt') as file:
+        with open(Path('banner_info', 'archive.txt')) as file:
             data = file.read()
         archive = json.loads(data, object_hook=jsonKeys2int)
 
@@ -188,7 +190,7 @@ def load_archive():
         return new_dict_c, new_dict_w
 
     except FileNotFoundError:
-        with open('.\\banner_info\\archive.txt', 'w') as file:
+        with open(Path('banner_info', 'archive.txt'), 'w') as file:
             file.write("[{}, {}]")
         return {}, {}
 


### PR DESCRIPTION
https://stackoverflow.com/questions/304883/what-do-i-use-on-linux-to-make-a-python-program-executable

This allows a *nix-system (e.g. Linux, macOS, etc.) to run the simulator with typing 'just' `./simulator.py` instead of `python3 simulator.py`.

https://stackoverflow.com/questions/42306410/gitignore-syntax-how-to-exclude-virtualenv-sub-directories

venv is extremely common as a virtualenv directory name.

As for Windows file paths, they don't work on *nix systems. (But please note that using default POSIX line separator -- '/' -- *does* work on Windows.)